### PR TITLE
Update installer.sh

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -145,7 +145,7 @@ if grep -q -i wsl /proc/version; then
 fi
 
 # distribution check
-if ! grep -q "ID_LIKE=debian" /etc/os-release 2>/dev/null ; then
+if ! grep -q "ID_LIKE=" /etc/os-release | grep -q "ubuntu\|debian" /etc/os-release 2>/dev/null ; then
   echo -e "\\n""$RED""EMBA only supports debian based distributions!""$NC\\n"
   print_help
   exit 1


### PR DESCRIPTION
Modified the distribution check to accept operating systems like Popthat are ubuntu/debian based and mention it differently in the /etc/os-release file

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Pop!_Os is based on both ubuntu and debian and has the string "ubuntu debian" in the ID_LIKE line in /etc/os-releases. I changed the grep line to accommodate to that and look for both strings


* **What is the current behavior?** (You can also link to an open issue here)
Installation will fail and saying that the current operating system isn't debian based


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Installer now runs on pop_os and supports regular ubuntu/debian distros as well


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

N/A

* **Other information**:
